### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,46 +1,46 @@
 {
-    "name":"io-event-reactor",
-    "version":"1.0.0-beta.5",
-    "description":"Module for conditionally reacting to watches and monitors on filesystem events by executing customizable plugins",
-    "main":"ioReactorService.js",
-    "directories":{
-        "test":"test"
-    },
-    "scripts":{
-        "test":"mocha test/all.js"
-    },
-    "keywords":[
-        "io",
-        "event",
-        "monitor",
-        "changes",
-        "alert",
-        "watch",
-        "file",
-        "directory",
-        "filesystem",
-        "directories"
-    ],
-    "dependencies":{
-        "node-uuid":"latest",
-        "io-event-reactor-plugin-support":"latest"
-    },
-    "devDependencies":{
-        "mocha":"latest"
-    },
-    "contributors":[
-        {
-            "name":"bitsofinfo",
-            "url":"http://bitsofinfo.wordpress.com"
-        }
-    ],
-    "license":"ISC",
-    "repository":{
-        "type":"git",
-        "url":"https://github.com/bitsofinfo/io-event-reactor.git"
-    },
-    "bugs":{
-        "url":"https://github.com/bitsofinfo/io-event-reactor/issues"
-    },
-    "homepage":"https://github.com/bitsofinfo/io-event-reactor"
+  "name": "io-event-reactor",
+  "version": "1.0.0-beta.5",
+  "description": "Module for conditionally reacting to watches and monitors on filesystem events by executing customizable plugins",
+  "main": "ioReactorService.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha test/all.js"
+  },
+  "keywords": [
+    "io",
+    "event",
+    "monitor",
+    "changes",
+    "alert",
+    "watch",
+    "file",
+    "directory",
+    "filesystem",
+    "directories"
+  ],
+  "dependencies": {
+    "io-event-reactor-plugin-support": "latest",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "mocha": "latest"
+  },
+  "contributors": [
+    {
+      "name": "bitsofinfo",
+      "url": "http://bitsofinfo.wordpress.com"
+    }
+  ],
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bitsofinfo/io-event-reactor.git"
+  },
+  "bugs": {
+    "url": "https://github.com/bitsofinfo/io-event-reactor/issues"
+  },
+  "homepage": "https://github.com/bitsofinfo/io-event-reactor"
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.